### PR TITLE
Fixed to Caret Requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ repository    = "https://github.com/alfiedotwtf/metaheuristics"
 license = "GPL-3.0"
 
 [dependencies]
-rand = "=0.8.4"
-time = "=0.3.5"
+rand = "^0.8.4"
+time = "^0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "metaheuristics"
-version = "1.1.19"
+version = "1.1.20"
 authors = ["Alfie John <alfie@alfie.wtf>"]
 
 description   = "Find approximate solutions to your optimisation problem using metaheuristics algorithms"


### PR DESCRIPTION
Move to caret requirements to allow clients to pull semver compatible dependencies updates.